### PR TITLE
Upgraded alpine and install gcc and alpine-sdk - Fixes #9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 ARG KUBECTL_VERSION="1.17.7"
 
-RUN apk add py-pip curl wget ca-certificates git bash jq
+RUN apk add py-pip curl wget ca-certificates git bash jq gcc alpine-sdk
 RUN pip install awscli
 RUN curl -L -o /usr/bin/kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.7/2020-07-08/bin/linux/amd64/kubectl
 RUN chmod +x /usr/bin/kubectl


### PR DESCRIPTION
An attempt to cleanly solve the issue described [here](https://github.com/koslib/helm-eks-action/issues/9).

The problem originally seems to have begun by Cython added as a dependency in PyYaml. By installing gcc in this alpine docker image, the problem goes away and the awscli installs successfully.