### PR TITLE
Security/kubeconfig chmod

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ echo ${KUBE_CONFIG_DATA} | base64 -d > kubeconfig
 export KUBECONFIG="${PWD}/kubeconfig"
 chmod 600 ${PWD}/kubeconfig
 
-if [-z $INPUT_PLUGINS]
+if [[ -n "${INPUT_PLUGINS// /}" ]]
 then
     plugins=$(echo $INPUT_PLUGINS | tr ",")
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 
 echo ${KUBE_CONFIG_DATA} | base64 -d > kubeconfig
 export KUBECONFIG="${PWD}/kubeconfig"
+chmod 600 ${PWD}/kubeconfig
 
 if [-z $INPUT_PLUGINS]
 then


### PR DESCRIPTION
Make the `kubeconfig` file not world-readable by explicitly setting owner/group read permissions.