### PR TITLE
Reinstated aws-iam-authenticator bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN pip install "awscli==${AWSCLI_VERSION}"
 RUN curl -L -o /usr/bin/kubectl https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 RUN chmod +x /usr/bin/kubectl
 
+RUN curl -o /usr/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator
+RUN chmod +x /usr/bin/aws-iam-authenticator
+
 RUN wget https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm
 RUN chmod +x /usr/local/bin/helm
 


### PR DESCRIPTION
Fixes the removal of `aws-iam-authenticator` from PR https://github.com/koslib/helm-eks-action/pull/29