### PR TITLE
Switch from set-output to github environment files

### DIFF
--- a/dockerhub/entrypoint.sh
+++ b/dockerhub/entrypoint.sh
@@ -21,4 +21,4 @@ echo "running entrypoint command(s)"
 
 response=$(sh -c " $INPUT_COMMAND")
 
-echo "::set-output name=response::$response"
+echo "response=$response" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Hello! 

Github has changed the way outputs get passed around to now use [environment files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files).

Full details are in this blog post on the topic:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This is a very tiny change that should quieten deprecation warnings in the workflow runner, and hopefully ensure this action continues to work when Github finally gets around to removing set-output.

p.s. Thanks for writing the action, it's dead helpful 💖 