### PR TITLE
Set output using multiline output syntax

### DIFF
--- a/dockerhub/entrypoint.sh
+++ b/dockerhub/entrypoint.sh
@@ -21,4 +21,6 @@ echo "running entrypoint command(s)"
 
 response=$(sh -c " $INPUT_COMMAND")
 
-echo "response=$response" >> $GITHUB_OUTPUT
+echo "response<<EOF" >> $GITHUB_OUTPUT
+echo "$response" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR fixes #56 by using the [multiline syntax](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings) for GitHub Actions outputs.

To test this code I've built a container image ([ghcr.io/miguelaferreira/ga-helm-eks:fix-issue-56](https://github.com/users/miguelaferreira/packages/container/ga-helm-eks/66536778?tag=fix-issue-56)) with the code in this PR. Then I used that image in a [workflow job](https://github.com/miguelaferreira/helm-eks-action/blob/test-fix-issue-56/.github/workflows/test-fix-issue.56.yaml) like this:
```yaml
jobs:
  test-fix:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - uses: "docker://ghcr.io/miguelaferreira/ga-helm-eks:fix-issue-56"
        id: action
        with:
          command: |
            echo "line 1"
            echo "line 2"
      - run: echo -e "Output from action is:\n${{ steps.action.outputs.response }}"
```

The [result](https://github.com/miguelaferreira/helm-eks-action/actions/runs/4032725217/jobs/6932787651#step:5:6) was the multiline output:
```
Output from action is:
line 1
line 2
```